### PR TITLE
Docker based statically linked build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,21 @@
-FROM nvidia/cuda:11.1.1-devel AS builder
+FROM nvidia/cuda:11.1.1-devel AS build-stage
 
 WORKDIR /build
-
 COPY . /build/
-
 RUN make
 
+RUN mkdir /build/libs
+RUN ldd ./gpu_burn | grep "=> /" | awk '{print $3}' | xargs -I '{}' cp -v '{}' /build/libs
+
+
+FROM scratch as export-stage
+COPY --from=build-stage /build/gpu_burn /
+COPY --from=build-stage /build/compare.ptx /
+COPY --from=build-stage /build/run_gpu_burn /
+COPY --from=build-stage /build/libs /libs
+
+
 FROM nvidia/cuda:11.1.1-runtime
-
-COPY --from=builder /build/gpu_burn /app/
-COPY --from=builder /build/compare.ptx /app/
-
+COPY --from=artifact / /app/
 WORKDIR /app
-
 CMD ["./gpu_burn", "60"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,18 @@
-FROM nvidia/cuda:10.0-devel-ubuntu16.04 AS build-stage
+ARG CUDA_VERSION=10.0
+ARG UBUNTU_VERSION=16.04
+FROM nvidia/cuda:${CUDA_VERSION}-devel-ubuntu${UBUNTU_VERSION} AS build-stage
 
 WORKDIR /build
 COPY . /build/
 RUN make
 
-RUN mkdir /build/libs
-RUN ldd ./gpu_burn | grep "=> /" | awk '{print $3}' | xargs -I '{}' cp -v '{}' /build/libs
-
 
 FROM scratch as export-stage
 COPY --from=build-stage /build/gpu_burn /
 COPY --from=build-stage /build/compare.ptx /
-COPY --from=build-stage /build/run_gpu_burn /
-COPY --from=build-stage /build/libs /libs
 
 
-FROM nvidia/cuda:11.1.1-runtime
+FROM nvidia/cuda:${CUDA_VERSION}-runtime-ubuntu${UBUNTU_VERSION}
 COPY --from=artifact / /app/
 WORKDIR /app
 CMD ["./gpu_burn", "60"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,6 @@ COPY --from=build-stage /build/compare.ptx /
 
 
 FROM nvidia/cuda:${CUDA_VERSION}-runtime-ubuntu${UBUNTU_VERSION}
-COPY --from=artifact / /app/
+COPY --from=export-stage / /app/
 WORKDIR /app
 CMD ["./gpu_burn", "60"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.1.1-devel AS build-stage
+FROM nvidia/cuda:10.0-devel-ubuntu16.04 AS build-stage
 
 WORKDIR /build
 COPY . /build/

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ LDFLAGS  += -L${CUDAPATH}/lib
 LDFLAGS  += -Wl,-rpath=${CUDAPATH}/lib64
 LDFLAGS  += -Wl,-rpath=${CUDAPATH}/lib
 LDFLAGS  += -lcublas_static
+# Required for newer CUDA versions in the future: LDFLAGS  += -lcublasLt_static
 LDFLAGS  += -lcudart_static
 LDFLAGS  += -lculibos
 LDFLAGS  += -ldl

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,12 @@ LDFLAGS  += -L${CUDAPATH}/lib64
 LDFLAGS  += -L${CUDAPATH}/lib
 LDFLAGS  += -Wl,-rpath=${CUDAPATH}/lib64
 LDFLAGS  += -Wl,-rpath=${CUDAPATH}/lib
-LDFLAGS  += -lcublas
-LDFLAGS  += -lcudart
+LDFLAGS  += -lcublas_static
+LDFLAGS  += -lcudart_static
+LDFLAGS  += -lculibos
+LDFLAGS  += -ldl
+LDFLAGS  += -pthread
+LDFLAGS  += -lrt
 
 COMPUTE   ?= 50
 

--- a/run_gpu_burn
+++ b/run_gpu_burn
@@ -1,8 +1,0 @@
-#! /usr/bin/env bash
-
-here="$(dirname "$(readlink -f "$0")")"
-if [[ -d $here/libs ]]; then
-    LD_LIBRARY_PATH=$here/libs:$LD_LIBRARY_PATH
-fi
-
-./gpu_burn "$@"

--- a/run_gpu_burn
+++ b/run_gpu_burn
@@ -1,0 +1,8 @@
+#! /usr/bin/env bash
+
+here="$(dirname "$(readlink -f "$0")")"
+if [[ -d $here/libs ]]; then
+    LD_LIBRARY_PATH=$here/libs:$LD_LIBRARY_PATH
+fi
+
+./gpu_burn "$@"


### PR DESCRIPTION
This is a prerequisite for including gpu-burn in the stress test.
It includes a Dockerfile to produce reproducible builds and small tweaks to the Makefile to statically link against the necessary libraries (statically linking cuda libraries requires additional dynamic linking against standard/gcc libraries).

The build is run like this (resulting binary and compare.ptx are stored in the folder `./build`)
`DOCKER_BUILDKIT=1 docker build --target export-stage --output type=local,dest=./build .`

I have tested the binary against the following combinations:
 - Driver Version: 460.91.03    CUDA Version: 11.2
 - Driver Version: 410.78       CUDA Version: 10.0