### PR TITLE
Docker based statically linked build for new HW

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,19 @@
-ARG CUDA_VERSION=11.8.0
-ARG IMAGE_DISTRO=ubi8
+ARG CUDA_VERSION=11.2.2
+ARG IMAGE_DISTRO=ubuntu16.04
+
 
 FROM nvidia/cuda:${CUDA_VERSION}-devel-${IMAGE_DISTRO} AS builder
-
 WORKDIR /build
-
 COPY . /build/
-
 RUN make
 
+
+FROM scratch as exporter
+COPY --from=builder /build/gpu_burn /
+COPY --from=builder /build/compare.ptx /
+
+
 FROM nvidia/cuda:${CUDA_VERSION}-runtime-${IMAGE_DISTRO}
-
-COPY --from=builder /build/gpu_burn /app/
-COPY --from=builder /build/compare.ptx /app/
-
+COPY --from=exporter / /app/
 WORKDIR /app
-
 CMD ["./gpu_burn", "60"]

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,16 @@ override LDFLAGS  += -L${CUDAPATH}/lib
 override LDFLAGS  += -L${CUDAPATH}/lib/stubs
 override LDFLAGS  += -Wl,-rpath=${CUDAPATH}/lib64
 override LDFLAGS  += -Wl,-rpath=${CUDAPATH}/lib
-override LDFLAGS  += -lcublas
-override LDFLAGS  += -lcudart
+# override LDFLAGS  += -lcublas
+# override LDFLAGS  += -lcudart
+# Static linking
+override LDFLAGS  += -lcublas_static
+override LDFLAGS  += -lcublasLt_static
+override LDFLAGS  += -lcudart_static
+override LDFLAGS  += -lculibos
+override LDFLAGS  += -ldl
+override LDFLAGS  += -pthread
+override LDFLAGS  += -lrt
 
 COMPUTE      ?= 50
 CUDA_VERSION ?= 11.8.0


### PR DESCRIPTION
I modified the Makefile to statically link against the cuda libraries.
This made it necessary to explicitly link against standard/gcc libraries as well.

I also modified the Dockerfile with an exporter stage
to output the produced binary and serve as a reproducible build environment.

This allows for easy and reproducible builds and is prerequisite of including gpu-burn in the new stress test.
Statically linking makes it nicely portable across servers 
without the need to install or bundle a runtime library.
This is a prerequisite for including gpu-burn in the stress test.

I have tested the binary against the following combinations:
  - Thinkmate Mega M3D 4.0.2 with Driver Version: 460.73.01    CUDA Version: 11.2
  - Dell Rack M3D 4.1.0 with Driver Version: 535.183.01        CUDA Version: 12.2

The build is run like this (resulting binary and compare.ptx are stored in the folder `./build`)
`DOCKER_BUILDKIT=1 docker build --target exporter --output type=local,dest=./build .`

